### PR TITLE
Register items regardless of Channels feature

### DIFF
--- a/src/main/java/appeng/bootstrap/BlockDefinitionBuilder.java
+++ b/src/main/java/appeng/bootstrap/BlockDefinitionBuilder.java
@@ -179,7 +179,7 @@ class BlockDefinitionBuilder implements IBlockBuilder
 	@Override
 	public <T extends IBlockDefinition> T build()
 	{
-		if( !AEConfig.instance().areFeaturesEnabled( this.features ) )
+		if( !AEConfig.instance().areFeaturesEnabled( this.features ) && !this.features.contains(AEFeature.CHANNELS))
 		{
 			return (T) new TileDefinition( this.registryName, null, null );
 		}

--- a/src/main/java/appeng/items/parts/PartType.java
+++ b/src/main/java/appeng/items/parts/PartType.java
@@ -323,7 +323,8 @@ public enum PartType
 		this.oreName = oreDict;
 
 		// The part is enabled if all features + integrations it needs are enabled
-		this.enabled = features.stream().allMatch( AEConfig.instance()::isFeatureEnabled ) && integrations.stream().allMatch( IntegrationRegistry.INSTANCE::isEnabled );
+		this.enabled = features.stream().allMatch((x) -> AEConfig.instance().isFeatureEnabled(x) || x == AEFeature.CHANNELS) && integrations.stream()
+				.allMatch( IntegrationRegistry.INSTANCE::isEnabled );
 
 		if( this.enabled )
 		{


### PR DESCRIPTION
This is a hack/change to always register block & items that are usually associated with channels, even if channels are disabled. This allows users to disable the "channels" config option, but still keep all of the items to keep proper progression gates in place (such as in Divine Journey 2).

E.g. the controller block disappears when channels are disabled, but is required as a crafting ingredient in late game recipes. This will ensure that the controller block is always craftable.