### PR TITLE
Sort Terminal by InventoryBogoSort Sort Rules

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,7 @@ top_version=1.12-1.4.23-16
 cofhcore_version=1.12.2-4.5.2.19
 crafttweaker_version=4.1.8.9
 inventorytweaks_version=1.63
+bogosorter_version=1.1.0
 ctm_version=MC1.12.2-0.3.1.16
 forestry_version=5.8.2.387
 #########################################################

--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -95,6 +95,7 @@ dependencies {
     compileOnly "cofh:CoFHCore:${cofhcore_version}:deobf"
     compileOnly "CraftTweaker2:CraftTweaker2-API:${crafttweaker_version}"
     compileOnly "inventory-tweaks:InventoryTweaks:${inventorytweaks_version}:api"
+    compileOnly "inventory-bogo-sorter:bogosorter:${bogosorter_version}"
     compileOnly "team.chisel.ctm:CTM:${ctm_version}"
     compileOnly "de.ellpeck.actuallyadditions:ActuallyAdditions:1.12.2-r152.16:api"
     deobfCompile "net.sengir.forestry:forestry_${minecraft_version}:$forestry_version"

--- a/src/main/java/appeng/client/me/ItemRepo.java
+++ b/src/main/java/appeng/client/me/ItemRepo.java
@@ -41,6 +41,7 @@ import appeng.client.gui.widgets.IScrollSource;
 import appeng.client.gui.widgets.ISortSource;
 import appeng.core.AEConfig;
 import appeng.integration.Integrations;
+import appeng.integration.modules.bogosorter.InventoryBogoSortModule;
 import appeng.items.storage.ItemViewCell;
 import appeng.util.ItemSorters;
 import appeng.util.Platform;
@@ -237,7 +238,14 @@ public class ItemRepo
 		}
 		else if( SortBy == SortOrder.INVTWEAKS )
 		{
-			Collections.sort( this.view, ItemSorters.CONFIG_BASED_SORT_BY_INV_TWEAKS );
+			if( InventoryBogoSortModule.isLoaded() )
+			{
+				Collections.sort( this.view, InventoryBogoSortModule.COMPARATOR );
+			}
+			else
+			{
+				Collections.sort( this.view, ItemSorters.CONFIG_BASED_SORT_BY_INV_TWEAKS );
+			}
 		}
 		else
 		{

--- a/src/main/java/appeng/integration/modules/bogosorter/InventoryBogoSortModule.java
+++ b/src/main/java/appeng/integration/modules/bogosorter/InventoryBogoSortModule.java
@@ -1,0 +1,19 @@
+package appeng.integration.modules.bogosorter;
+
+import appeng.api.storage.data.IAEItemStack;
+import com.cleanroommc.bogosorter.common.sort.SortHandler;
+import net.minecraftforge.fml.common.Loader;
+
+import java.util.Comparator;
+
+public class InventoryBogoSortModule
+{
+    private static final boolean loaded = Loader.isModLoaded("bogosorter");
+
+    public static final Comparator<IAEItemStack> COMPARATOR = (o1, o2) -> SortHandler.ITEM_COMPARATOR.compare(o1.getDefinition(), o2.getDefinition());
+
+    public static boolean isLoaded() {
+
+        return loaded;
+    }
+}

--- a/src/main/java/appeng/util/Platform.java
+++ b/src/main/java/appeng/util/Platform.java
@@ -129,6 +129,7 @@ import appeng.core.sync.GuiHostType;
 import appeng.fluids.util.AEFluidStack;
 import appeng.hooks.TickHandler;
 import appeng.integration.Integrations;
+import appeng.integration.modules.bogosorter.InventoryBogoSortModule;
 import appeng.me.GridAccessException;
 import appeng.me.GridNode;
 import appeng.me.helpers.AENetworkProxy;
@@ -354,7 +355,7 @@ public class Platform
 
 	private static boolean isNotValidSetting( final Enum e )
 	{
-		if( e == SortOrder.INVTWEAKS && !Integrations.invTweaks().isEnabled() )
+		if( e == SortOrder.INVTWEAKS && !Integrations.invTweaks().isEnabled() && !InventoryBogoSortModule.isLoaded() )
 		{
 			return true;
 		}


### PR DESCRIPTION
Simply when InventoryBogoSort is installedm the terminals can sort their content by the mods configured sort rules. It uses the Inventory Tweaks sort option in the terminal. If Inv Tweaks is also installed it will be ignored.