### PR TITLE
fix expended pattern terminal can't place item manually

### DIFF
--- a/src/main/java/appeng/parts/reporting/PartExpandedProcessingPatternTerminal.java
+++ b/src/main/java/appeng/parts/reporting/PartExpandedProcessingPatternTerminal.java
@@ -32,6 +32,17 @@ public class PartExpandedProcessingPatternTerminal extends AbstractPartEncoder {
         this.crafting = new AppEngInternalInventory(this, PROCESSING_INPUT_LIMIT);
         this.output = new AppEngInternalInventory(this, PROCESSING_OUTPUT_LIMIT);
         this.pattern = new AppEngInternalInventory(this, 2);
+        this.craftingMode = false;
+    }
+
+    @Override
+    public boolean isCraftingRecipe() {
+        return false;
+    }
+
+    @Override
+    public void setCraftingRecipe(final boolean craftingMode) {
+        // NO-OP
     }
 
     @Override


### PR DESCRIPTION
because expended pattern terminal is always on crafting mode so every slot only can accept one item