### PR TITLE
fix ae fluid inventory fluid exceeding

### DIFF
--- a/src/main/java/appeng/fluids/util/AEFluidInventory.java
+++ b/src/main/java/appeng/fluids/util/AEFluidInventory.java
@@ -104,9 +104,7 @@ public class AEFluidInventory implements IAEFluidTank {
 
         if (doFill) {
             if (fluid == null) {
-                AEFluidStack tmp = AEFluidStack.fromFluidStack(resource);
-                tmp.setStackSize(amountToStore);
-                this.setFluidInSlot(slot, tmp);
+                this.setFluidInSlot(slot, AEFluidStack.fromFluidStack(resource).setStackSize(amountToStore));
             } else {
                 fluid.setStackSize(fluid.getStackSize() + amountToStore);
                 this.onContentChanged(slot);

--- a/src/main/java/appeng/fluids/util/AEFluidInventory.java
+++ b/src/main/java/appeng/fluids/util/AEFluidInventory.java
@@ -104,7 +104,9 @@ public class AEFluidInventory implements IAEFluidTank {
 
         if (doFill) {
             if (fluid == null) {
-                this.setFluidInSlot(slot, AEFluidStack.fromFluidStack(resource));
+                AEFluidStack tmp = AEFluidStack.fromFluidStack(resource);
+                tmp.setStackSize(amountToStore);
+                this.setFluidInSlot(slot, tmp);
             } else {
                 fluid.setStackSize(fluid.getStackSize() + amountToStore);
                 this.onContentChanged(slot);


### PR DESCRIPTION
if something trying to input too much fluid in an empty slot, it will cause fluid dupe.
![image](https://user-images.githubusercontent.com/60341015/198832569-8919e4ab-d857-4a9e-9874-47ca28d53820.png)
fix https://github.com/GlodBlock/AE2FluidCraft-Rework/issues/59
