### PR TITLE
fix patterns not respecting item models and colors...

### DIFF
--- a/src/main/java/appeng/client/ClientHelper.java
+++ b/src/main/java/appeng/client/ClientHelper.java
@@ -23,6 +23,7 @@ import appeng.api.parts.CableRenderMode;
 import appeng.api.util.AEColor;
 import appeng.block.AEBaseBlock;
 import appeng.client.gui.AEBaseGui;
+import appeng.client.render.crafting.ItemEncodedPatternBakedModel;
 import appeng.client.render.effects.*;
 import appeng.client.render.model.UVLModelLoader;
 import appeng.client.render.tesr.InscriberTESR;
@@ -30,6 +31,7 @@ import appeng.client.render.textures.ParticleTextures;
 import appeng.container.interfaces.IJEIGhostIngredients;
 import appeng.core.AEConfig;
 import appeng.core.AELog;
+import appeng.core.Api;
 import appeng.core.AppEng;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketAssemblerAnimation;
@@ -96,6 +98,9 @@ public class ClientHelper extends ServerHelper {
             ClientRegistry.registerKeyBinding(binding);
             this.bindings.put(key, binding);
         }
+
+        Api.INSTANCE.definitions().items().encodedPattern().maybeItem().ifPresent(pattern ->
+                Minecraft.getMinecraft().getItemColors().registerItemColorHandler(ItemEncodedPatternBakedModel.PATTERN_ITEM_COLOR_HANDLER, pattern));
     }
 
     @SubscribeEvent


### PR DESCRIPTION
...when shift key is held and the "output" item in the pattern is rendered instead of the base pattern texture

Consequences:
- The "output" item of the pattern will now be rendered always when shift is held, not just when the TransformType is GUI.
    - This means that you will see the "output" item now for in-world patterns, as well as the rendered model in the player's hand or offhand
    - However, I honestly think this is an improvement from before