### PR TITLE
Fix being unable to clear selected text in number boxes

### DIFF
--- a/src/main/java/appeng/client/gui/widgets/GuiNumberBox.java
+++ b/src/main/java/appeng/client/gui/widgets/GuiNumberBox.java
@@ -37,6 +37,9 @@ public class GuiNumberBox extends GuiTextField {
         final String original = this.getText();
         super.writeText(selectedText);
 
+        if (this.getText().isEmpty()) {
+            return;
+        }
         try {
             if (this.type == int.class || this.type == Integer.class) {
                 Integer.parseInt(this.getText());


### PR DESCRIPTION
Currently you can't use backspace to clear the number box in the craft amount window because of this funny method