### PR TITLE
Refresh crafting plan when job submission fails

### DIFF
--- a/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
+++ b/src/main/java/appeng/container/implementations/ContainerCraftConfirm.java
@@ -305,7 +305,9 @@ public class ContainerCraftConfirm extends AEBaseContainer {
             final ICraftingGrid cc = this.getGrid().getCache(ICraftingGrid.class);
             final ICraftingLink g = cc.submitJob(this.result, null, this.getSelectedCpu() == -1 ? null : this.cpus.get(this.getSelectedCpu()).getCpu(), true, this.getActionSrc());
             this.setAutoStart(false);
-            if (g != null && originalGui != null && this.getOpenContext() != null) {
+            if (g == null) {
+                this.setJob(cc.beginCraftingJob(this.getWorld(), this.getGrid(), this.getActionSrc(), this.result.getOutput(), null));
+            } else if (originalGui != null && this.getOpenContext() != null) {
                 final TileEntity te = this.getOpenContext().getTile();
                 if (te != null) {
                     Platform.openGUI(this.getInventoryPlayer().player, te, this.getOpenContext().getSide(), originalGui);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1492543/226205733-8b25ae03-1de8-44e0-be7b-67394c7e4f93.png)

Automatically refreshes the crafting plan when this happens, so the player doesn't have to do three extra steps.
It happens quite frequently on my server as there are many automated processes that use up stored resources.