### PR TITLE
Interface shift-clicking QOL improvements

### DIFF
--- a/src/main/java/appeng/container/slot/SlotRestrictedInput.java
+++ b/src/main/java/appeng/container/slot/SlotRestrictedInput.java
@@ -65,6 +65,10 @@ public class SlotRestrictedInput extends AppEngSlot {
         this.p = p;
     }
 
+    public PlacableItemType getPlaceableItemType() {
+        return which;
+    }
+
     @Override
     public int getSlotStackLimit() {
         if (this.stackLimit != -1) {


### PR DESCRIPTION
Added a few QOL improvements to interfaces when shift-clicking into them:

1. Shift-clicking a stack of encoded patterns (now that they are stackable) will only insert one pattern into a slot, instead of filling all available slots and then overflowing into main storage
2. Shift-clicking an encoded pattern will not insert the pattern if the interface already has the exact same pattern inside of it 
3. Shift-clicking pattern expansion cards will only insert up to the maximum useful amount of expansions (3), and will not overflow into main storage 

I tested the changes locally, it all works as intended. 