### PR TITLE
add config controlling if JEI crafting grid recipes can error

### DIFF
--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -83,6 +83,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     private int craftingCalculationTimePerTick = 5;
     private PowerUnits selectedPowerUnit = PowerUnits.AE;
     private boolean showCraftableTooltip = true;
+    private boolean allowMissingItemsToPreventTransfer = true;
     // Spatial IO/Dimension
     private int storageProviderID = -1;
     private int storageDimensionID = -1;
@@ -250,6 +251,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.useLargeFonts = this.get("Client", "useTerminalUseLargeFont", false).getBoolean(false);
         this.useColoredCraftingStatus = this.get("Client", "useColoredCraftingStatus", true).getBoolean(true);
         this.showCraftableTooltip = this.get("Client", "showCraftableTooltip", true, "Whether to add \"Craftable\" to item tooltips when they can be crafted automatically.").getBoolean(true);
+        this.allowMissingItemsToPreventTransfer = this.get("Client", "allowMissingItemsToPreventTransfer", true, "Whether to allow JEI's Transfer recipe functionality to be prevented due to missing items. False will attempt to insert all valid available items.").getBoolean(true);
 
         // load buttons..
         for (int btnNum = 0; btnNum < 4; btnNum++) {
@@ -505,6 +507,10 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 
     public boolean isShowCraftableTooltip() {
         return this.showCraftableTooltip;
+    }
+
+    public boolean isAllowMissingItemsToPreventTransfer() {
+        return this.allowMissingItemsToPreventTransfer;
     }
 
     public boolean isDisableColoredCableRecipesInJEI() {

--- a/src/main/java/appeng/integration/modules/jei/JEIMissingItem.java
+++ b/src/main/java/appeng/integration/modules/jei/JEIMissingItem.java
@@ -11,6 +11,7 @@ import appeng.client.gui.implementations.GuiWirelessCraftingTerminal;
 import appeng.container.implementations.ContainerCraftingTerm;
 import appeng.container.implementations.ContainerMEMonitorable;
 import appeng.container.implementations.ContainerWirelessCraftingTerminal;
+import appeng.core.AEConfig;
 import appeng.helpers.IContainerCraftingPacket;
 import appeng.util.IConfigManagerHost;
 import appeng.util.Platform;
@@ -53,6 +54,8 @@ public class JEIMissingItem implements IRecipeTransferError {
             boolean found;
             this.errored = false;
             recipeLayout.getItemStacks().addTooltipCallback(new CraftableCallBack(container, available));
+
+            if (!AEConfig.instance().isAllowMissingItemsToPreventTransfer()) return;
 
             IItemList<IAEItemStack> used = AEApi.instance().storage().getStorageChannel(IItemStorageChannel.class).createList();
             for (IGuiIngredient<?> i : recipeLayout.getItemStacks().getGuiIngredients().values()) {
@@ -112,7 +115,7 @@ public class JEIMissingItem implements IRecipeTransferError {
     @Override
     public void showError(Minecraft minecraft, int mouseX, int mouseY, @Nonnull IRecipeLayout recipeLayout, int recipeX, int recipeY) {
         Container c = minecraft.player.openContainer;
-        if (c instanceof ContainerMEMonitorable) {
+        if (c instanceof ContainerMEMonitorable && AEConfig.instance().isAllowMissingItemsToPreventTransfer()) {
             ContainerMEMonitorable container = (ContainerMEMonitorable) c;
             IItemList<IAEItemStack> ir = ((ContainerMEMonitorable) c).items;
             boolean found;


### PR DESCRIPTION
Adds a config controlling if having missing items in a recipe will prevent using the + in the JEI GUI to move items to the crafting grid.
Defaults to `true`, as that is the current behavior. Changing it to `false` will revert ae2 behavior to before 0.54.1.

To test: open up a world, open up a ME Crafting Terminal, and view the recipe of an item you cannot craft with the items in the system. With the setting being `true`, the + button will be greyed out and missing/craftable items highlighted. With the setting being `false`, the button will be clickable and will transfer all possible items into the ME Crafting Terminal.
