### PR TITLE
Configurable Channel Limits

### DIFF
--- a/src/main/java/appeng/client/render/cablebus/CableBuilder.java
+++ b/src/main/java/appeng/client/render/cablebus/CableBuilder.java
@@ -22,6 +22,7 @@ package appeng.client.render.cablebus;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
 import appeng.core.AppEng;
+import appeng.core.AEConfig;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.VertexFormat;
@@ -327,8 +328,8 @@ class CableBuilder {
         TextureAtlasSprite texture = this.connectionTextures.get(AECableType.SMART).get(cableColor);
         cubeBuilder.setTexture(texture);
 
-        TextureAtlasSprite oddChannel = this.smartCableTextures.getOddTextureForChannels(channels);
-        TextureAtlasSprite evenChannel = this.smartCableTextures.getEvenTextureForChannels(channels);
+        TextureAtlasSprite oddChannel = this.smartCableTextures.getOddTextureForChannels((int) (channels / (AEConfig.instance().getNormalChannelCapacity() / 8)));
+        TextureAtlasSprite evenChannel = this.smartCableTextures.getEvenTextureForChannels((int) (channels / (AEConfig.instance().getNormalChannelCapacity() / 8)));
 
         // For to-machine connections, use a thicker end-cap for the connection
         if (connectionType != AECableType.GLASS && !cableBusAdjacent) {
@@ -374,8 +375,8 @@ class CableBuilder {
 
         addStraightCoveredCableSizedCube(facing, cubeBuilder);
 
-        TextureAtlasSprite oddChannel = this.smartCableTextures.getOddTextureForChannels(channels);
-        TextureAtlasSprite evenChannel = this.smartCableTextures.getEvenTextureForChannels(channels);
+        TextureAtlasSprite oddChannel = this.smartCableTextures.getOddTextureForChannels((int) (channels / (AEConfig.instance().getNormalChannelCapacity() / 8)));
+        TextureAtlasSprite evenChannel = this.smartCableTextures.getEvenTextureForChannels((int) (channels / (AEConfig.instance().getNormalChannelCapacity() / 8)));
 
         // Render the channel indicators brightly lit at night
         cubeBuilder.setRenderFullBright(true);
@@ -403,8 +404,8 @@ class CableBuilder {
 
         addCoveredCableSizedCube(facing, distanceFromEdge, cubeBuilder);
 
-        TextureAtlasSprite oddChannel = this.smartCableTextures.getOddTextureForChannels(channels);
-        TextureAtlasSprite evenChannel = this.smartCableTextures.getEvenTextureForChannels(channels);
+        TextureAtlasSprite oddChannel = this.smartCableTextures.getOddTextureForChannels((int) (channels / (AEConfig.instance().getNormalChannelCapacity() / 8)));
+        TextureAtlasSprite evenChannel = this.smartCableTextures.getEvenTextureForChannels((int) (channels / (AEConfig.instance().getNormalChannelCapacity() / 8)));
 
         // Render the channel indicators brightly lit at night
         cubeBuilder.setRenderFullBright(true);
@@ -464,7 +465,7 @@ class CableBuilder {
         addDenseCableSizedCube(facing, cubeBuilder);
 
         // Dense cables show used channels in groups of 4, rounded up
-        channels = (channels + 3) / 4;
+        channels = (int) ((channels + 3) / 4) / (AEConfig.instance().getDenseChannelCapacity() / 32);
 
         TextureAtlasSprite oddChannel = this.smartCableTextures.getOddTextureForChannels(channels);
         TextureAtlasSprite evenChannel = this.smartCableTextures.getEvenTextureForChannels(channels);
@@ -508,7 +509,7 @@ class CableBuilder {
         addStraightDenseCableSizedCube(facing, cubeBuilder);
 
         // Dense cables show used channels in groups of 4, rounded up
-        channels = (channels + 3) / 4;
+        channels = (int) ((channels + 3) / 4) / (AEConfig.instance().getDenseChannelCapacity() / 32);
 
         TextureAtlasSprite oddChannel = this.smartCableTextures.getOddTextureForChannels(channels);
         TextureAtlasSprite evenChannel = this.smartCableTextures.getEvenTextureForChannels(channels);

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -143,6 +143,8 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         CondenserOutput.SINGULARITY.requiredPower = this.get("Condenser", "Singularity", 256000).getInt(256000);
 
         this.removeCrashingItemsOnLoad = this.get("general", "removeCrashingItemsOnLoad", false, "Will auto-remove items that crash when being loaded from storage. This will destroy those items instead of crashing the game!").getBoolean();
+        this.normalChannelCapacity = this.get("general", "normalChannelCapacity", this.normalChannelCapacity).getInt(this.normalChannelCapacity);
+        this.denseChannelCapacity = this.get("general", "denseChannelCapacity", this.denseChannelCapacity).getInt(this.denseChannelCapacity);
 
         this.setCategoryComment("BlockingMode", "Map of items to not block when blockingmode is enabled.\n[modid]\nmodid:item:metadata(optional,default:0)\nSupports more than one modid, so you can block different things between, for example, gregtech or enderio");
         this.nonBlockingItems = this.get("BlockingMode", "nonBlockingItems", nonBlockingItems, "NonBlockingItems").getStringList();
@@ -193,8 +195,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.maxControllerSizeY = Math.min(Math.max(this.get("ControllerSize", "maxControllerSizeY", this.maxControllerSizeY).getInt(this.maxControllerSizeY), 1), 63);
         this.maxControllerSizeZ = Math.min(Math.max(this.get("ControllerSize", "maxControllerSizeZ", this.maxControllerSizeZ).getInt(this.maxControllerSizeZ), 1), 63);
 
-        this.normalChannelCapacity = this.get("misc", "normal channel capacity", this.normalChannelCapacity.getInt(this.normalChannelCapacity));
-        this.denseChannelCapacity = this.get("misc", "dense channel capacity", this.denseChannelCapacity.getInt(this.denseChannelCapacity));
+
 
         this.clientSync();
 

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -83,8 +83,7 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     private int craftingCalculationTimePerTick = 5;
     private PowerUnits selectedPowerUnit = PowerUnits.AE;
     private boolean showCraftableTooltip = true;
-    private int normalChannelCapacity = 8;
-    private int denseChannelCapacity = 32;
+
     // Spatial IO/Dimension
     private int storageProviderID = -1;
     private int storageDimensionID = -1;

--- a/src/main/java/appeng/core/AEConfig.java
+++ b/src/main/java/appeng/core/AEConfig.java
@@ -83,6 +83,8 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     private int craftingCalculationTimePerTick = 5;
     private PowerUnits selectedPowerUnit = PowerUnits.AE;
     private boolean showCraftableTooltip = true;
+    private int normalChannelCapacity = 8;
+    private int denseChannelCapacity = 32;
     // Spatial IO/Dimension
     private int storageProviderID = -1;
     private int storageDimensionID = -1;
@@ -121,6 +123,9 @@ public final class AEConfig extends Configuration implements IConfigurableObject
     private int maxControllerSizeX = 7;
     private int maxControllerSizeY = 7;
     private int maxControllerSizeZ = 7;
+
+    private int normalChannelCapacity = 8;
+    private int denseChannelCapacity = 32;
 
     private AEConfig(final File configFile) {
         super(configFile);
@@ -188,6 +193,9 @@ public final class AEConfig extends Configuration implements IConfigurableObject
         this.maxControllerSizeX = Math.min(Math.max(this.get("ControllerSize", "maxControllerSizeX", this.maxControllerSizeX).getInt(this.maxControllerSizeX), 1), 63);
         this.maxControllerSizeY = Math.min(Math.max(this.get("ControllerSize", "maxControllerSizeY", this.maxControllerSizeY).getInt(this.maxControllerSizeY), 1), 63);
         this.maxControllerSizeZ = Math.min(Math.max(this.get("ControllerSize", "maxControllerSizeZ", this.maxControllerSizeZ).getInt(this.maxControllerSizeZ), 1), 63);
+
+        this.normalChannelCapacity = this.get("misc", "normal channel capacity", this.normalChannelCapacity.getInt(this.normalChannelCapacity));
+        this.denseChannelCapacity = this.get("misc", "dense channel capacity", this.denseChannelCapacity.getInt(this.denseChannelCapacity));
 
         this.clientSync();
 
@@ -675,5 +683,13 @@ public final class AEConfig extends Configuration implements IConfigurableObject
 
     public int getMaxControllerSizeZ() {
         return this.maxControllerSizeZ;
+    }
+
+    public int getNormalChannelCapacity() {
+        return this.normalChannelCapacity;
+    }
+
+    public int getDenseChannelCapacity() {
+        return this.denseChannelCapacity;
     }
 }

--- a/src/main/java/appeng/integration/modules/theoneprobe/part/ChannelInfoProvider.java
+++ b/src/main/java/appeng/integration/modules/theoneprobe/part/ChannelInfoProvider.java
@@ -43,7 +43,7 @@ public class ChannelInfoProvider implements IPartProbInfoProvider {
         }
         if (part instanceof PartDenseCableSmart || part instanceof PartCableSmart) {
             final int usedChannels;
-            final int maxChannels = (part instanceof PartDenseCableSmart) ? 32 : 8;
+            final int maxChannels = (part instanceof PartDenseCableSmart) ? AEConfig.instance().getDenseChannelCapacity() : AEConfig.instance().getNormalChannelCapacity();
 
             if (part.getGridNode().isActive()) {
                 final NBTTagCompound tmp = new NBTTagCompound();

--- a/src/main/java/appeng/integration/modules/waila/part/ChannelWailaDataProvider.java
+++ b/src/main/java/appeng/integration/modules/waila/part/ChannelWailaDataProvider.java
@@ -81,7 +81,7 @@ public final class ChannelWailaDataProvider extends BasePartWailaDataProvider {
             final byte usedChannels = this.getUsedChannels(part, tag, this.cache);
 
             if (usedChannels >= 0) {
-                final byte maxChannels = (byte) ((part instanceof PartDenseCableSmart) ? 32 : 8);
+                final byte maxChannels = (byte) ((part instanceof PartDenseCableSmart) ? AEConfig.instance().getDenseChannelCapacity() : AEConfig.instance().getNormalChannelCapacity());
 
                 final String formattedToolTip = String.format(WailaText.Channels.getLocal(), usedChannels, maxChannels);
                 currentToolTip.add(formattedToolTip);

--- a/src/main/java/appeng/me/GridConnection.java
+++ b/src/main/java/appeng/me/GridConnection.java
@@ -145,7 +145,7 @@ public class GridConnection implements IGridConnection, IPathItem {
 
     @Override
     public boolean canSupportMoreChannels() {
-        return this.getLastUsedChannels() < 32; // max, PERIOD.
+        return this.getLastUsedChannels() < AEConfig.instance().getDenseChannelCapacity(); // max, PERIOD.
     }
 
     @Override

--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -48,7 +48,7 @@ import java.util.*;
 
 public class GridNode implements IGridNode, IPathItem {
     private static final MENetworkChannelsChanged EVENT = new MENetworkChannelsChanged();
-    private static final int[] CHANNEL_COUNT = {0, 8, 32};
+    private static final int[] CHANNEL_COUNT = {0, AEConfig.instance().getNormalChannelCapacity(), AEConfig.instance().getDenseChannelCapacity};
 
     private final List<IGridConnection> connections = new ArrayList<>();
     private final IGridBlock gridProxy;

--- a/src/main/java/appeng/me/GridNode.java
+++ b/src/main/java/appeng/me/GridNode.java
@@ -48,7 +48,7 @@ import java.util.*;
 
 public class GridNode implements IGridNode, IPathItem {
     private static final MENetworkChannelsChanged EVENT = new MENetworkChannelsChanged();
-    private static final int[] CHANNEL_COUNT = {0, AEConfig.instance().getNormalChannelCapacity(), AEConfig.instance().getDenseChannelCapacity};
+    private static final int[] CHANNEL_COUNT = {0, AEConfig.instance().getNormalChannelCapacity(), AEConfig.instance().getDenseChannelCapacity()};
 
     private final List<IGridConnection> connections = new ArrayList<>();
     private final IGridBlock gridProxy;

--- a/src/main/java/appeng/me/cache/PathGridCache.java
+++ b/src/main/java/appeng/me/cache/PathGridCache.java
@@ -83,7 +83,7 @@ public class PathGridCache implements IPathingGrid {
             if (this.controllerState == ControllerState.NO_CONTROLLER) {
                 final int requiredChannels = this.calculateRequiredChannels();
                 int used = requiredChannels;
-                if (AEConfig.instance().isFeatureEnabled(AEFeature.CHANNELS) && requiredChannels > 8) {
+                if (AEConfig.instance().isFeatureEnabled(AEFeature.CHANNELS) && requiredChannels > AEConfig.instance().getNormalChannelCapacity()) {
                     used = 0;
                 }
 

--- a/src/main/java/appeng/parts/CableBusContainer.java
+++ b/src/main/java/appeng/parts/CableBusContainer.java
@@ -34,6 +34,7 @@ import appeng.client.render.cablebus.CableBusRenderState;
 import appeng.client.render.cablebus.CableCoreType;
 import appeng.client.render.cablebus.FacadeRenderState;
 import appeng.core.AELog;
+import appeng.core.AEConfig;
 import appeng.facade.FacadeContainer;
 import appeng.helpers.AEMultiTile;
 import appeng.me.GridConnection;
@@ -1022,7 +1023,7 @@ public class CableBusContainer extends CableBusStorage implements AEMultiTile, I
                 }
 
                 int length = (int) part.getCableConnectionLength(null);
-                if (length > 0 && length <= 8) {
+                if (length > 0 && length <= AEConfig.instance().getNormalChannelCapacity()) {
                     renderState.getAttachmentConnections().put(facing, length);
                 }
             }


### PR DESCRIPTION
I added a way to allow the player or pack dev, etc., to set a nonstandard number of channels for the network to use, for example, 64 and 8 or 128 and 32, to allow people to play with more flexible networks without having to disable channels entirely.

It has a config option for dense and normal channel amounts and linked all hard-coded values to the config option to avoid issues with improper channel assignments.

Scaled the rendering class to show the appropriate number of channels to the corresponding proportional texture.
Added support for all the ToP-like mods to allow for it to be seen correctly.

Tested on server and sp and it seamed to work correctly for me.