### PR TITLE
Add fix for leaking client TEs

### DIFF
--- a/src/main/java/appeng/hooks/TickHandler.java
+++ b/src/main/java/appeng/hooks/TickHandler.java
@@ -32,6 +32,7 @@ import appeng.me.Grid;
 import appeng.tile.AEBaseTile;
 import appeng.util.IWorldCallable;
 import appeng.util.Platform;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
@@ -66,7 +67,20 @@ public class TickHandler {
         return this.cliPlayerColors;
     }
 
+    /**
+     * Add a server or world callback which gets called the next time the queue is ticked.
+     * <p>
+     * Callbacks on the client are not support.
+     * <p>
+     * Using null as world will queue it into the global {@link TickEvent.ServerTickEvent}, otherwise it will be ticked with the
+     * corresponding {@link TickEvent.WorldTickEvent}.
+     *
+     * @param w null or the specific {@link World}
+     * @param c the callback
+     */
     public void addCallable(final World w, final IWorldCallable<?> c) {
+        Preconditions.checkArgument(w == null || !w.isRemote, "Can only register serverside callbacks");
+
         if (w == null) {
             this.serverQueue.add(c);
         } else {

--- a/src/main/java/appeng/tile/AEBaseTile.java
+++ b/src/main/java/appeng/tile/AEBaseTile.java
@@ -434,21 +434,16 @@ public class AEBaseTile extends TileEntity implements IOrientable, ICommonTile, 
     }
 
     public void saveChanges() {
-        if (this.world == null) {
+        // Clientside should not need to save/markDirty() data
+        if (this.world == null || this.world.isRemote) {
             return;
         }
 
-        // Clientside is marked immediately as dirty as there is no queue processing
         // Serverside is only queued once per tick to avoid costly operations
-        // TODO: Evaluate if this is still necessary
-        if (this.world.isRemote) {
-            this.markDirty();
-        } else {
-            this.world.markChunkDirty(this.pos, this);
-            if (!this.markDirtyQueued) {
-                TickHandler.INSTANCE.addCallable(null, this::markDirtyAtEndOfTick);
-                this.markDirtyQueued = true;
-            }
+        this.world.markChunkDirty(this.pos, this);
+        if (!this.markDirtyQueued) {
+            TickHandler.INSTANCE.addCallable(null, this::markDirtyAtEndOfTick);
+            this.markDirtyQueued = true;
         }
     }
 

--- a/src/main/java/appeng/tile/AEBaseTile.java
+++ b/src/main/java/appeng/tile/AEBaseTile.java
@@ -434,7 +434,16 @@ public class AEBaseTile extends TileEntity implements IOrientable, ICommonTile, 
     }
 
     public void saveChanges() {
-        if (this.world != null) {
+        if (this.world == null) {
+            return;
+        }
+
+        // Clientside is marked immediately as dirty as there is no queue processing
+        // Serverside is only queued once per tick to avoid costly operations
+        // TODO: Evaluate if this is still necessary
+        if (this.world.isRemote) {
+            this.markDirty();
+        } else {
             this.world.markChunkDirty(this.pos, this);
             if (!this.markDirtyQueued) {
                 TickHandler.INSTANCE.addCallable(null, this::markDirtyAtEndOfTick);


### PR DESCRIPTION
Adds/backports AppliedEnergistics/Applied-Energistics-2#5006. Not too sure if the issue(s) it fixed in the original mod are reproduceable in this fork, but better safe than sorry (especially since this code is [still used](https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/master/src/main/java/appeng/blockentity/AEBaseBlockEntity.java#L393) in modern versions). I *think* this was causing `TickHandler` to hold onto references of old client objects on the client-side as a side effect, don't quote me on that though.