### PR TITLE
Fix Matter Condenser's math & remove Player's maven

### DIFF
--- a/gradle/scripts/dependencies.gradle
+++ b/gradle/scripts/dependencies.gradle
@@ -44,11 +44,6 @@ repositories {
     }
 
     maven {
-        name = "IC2 repo"
-        url = "http://maven.ic2.player.to"
-    }
-
-    maven {
         name = "CoFH Maven"
         url = "http://maven.covers1624.net"
     }
@@ -102,7 +97,8 @@ dependencies {
     compileOnly "curse.maven:item-stages-280316:2696769"
     compileOnly "curse.maven:game-stages-268655:2951844"
     compileOnly "net.darkhax.tesla:Tesla-1.12.2:${tesla_version}"
-    compileOnly "net.industrial-craft:industrialcraft-2:${ic2_version}:api"
+    //compileOnly "net.industrial-craft:industrialcraft-2:${ic2_version}:api"
+    implementation rfg.deobf("curse.maven:industrial-craft-242638:2547175")
     compileOnly "mcjty.theoneprobe:TheOneProbe-1.12:${top_version}:api"
     compileOnly "curse.maven:CoFHCore-69162:2920433"
     compileOnly "CraftTweaker2:CraftTweaker2-API:${crafttweaker_version}"
@@ -110,7 +106,7 @@ dependencies {
     compileOnly "curse.maven:inventory-bogo-sorter-632327:4399738"
     compileOnly "team.chisel.ctm:CTM:${ctm_version}"
     compileOnly "de.ellpeck.actuallyadditions:ActuallyAdditions:1.12.2-r152.16:api"
-    implementation rfg.deobf("net.sengir.forestry:forestry_${minecraft_version}:$forestry_version")
+    implementation rfg.deobf("curse.maven:forestry-59751:2684780")
 
     // at runtime, use the full JEI jar
     runtimeOnly "mezz.jei:jei_${minecraft_version}:${jei_version}"

--- a/src/main/java/appeng/tile/misc/TileCondenser.java
+++ b/src/main/java/appeng/tile/misc/TileCondenser.java
@@ -118,7 +118,7 @@ public class TileCondenser extends AEBaseInvTile implements IConfigManagerHost, 
         while (requiredPower <= this.getStoredPower() && !output.isEmpty() && requiredPower > 0) {
             if (this.canAddOutput(output)) {
                 this.setStoredPower(this.getStoredPower() - requiredPower);
-                this.addOutput(output);
+                this.addOutput(output.copy());
             } else {
                 break;
             }
@@ -176,7 +176,7 @@ public class TileCondenser extends AEBaseInvTile implements IConfigManagerHost, 
                 while (requiredPower <= this.getStoredPower() && !output.isEmpty() && requiredPower > 0) {
                     if (this.canAddOutput(output)) {
                         this.setStoredPower(this.getStoredPower() - requiredPower);
-                        this.addOutput(output);
+                        this.addOutput(output.copy());
                     } else {
                         break;
                     }


### PR DESCRIPTION
# Explaination

The default Matter Condenser behavior is broken. In the while loop, the `output` stack gets progressively compounded with itself, resulting in products requiring way less power than they're supposed to drain.

For example, filling a Condenser with 16384 power and making Matter Balls (256 power per) would result in only 1792 power being drained to create an entire stack, vs. the expected 16384. This is because `output` is being grown by Forge down the line, so instead of adding 1 Ball per step, it ends up compounding the output, 1 -> 2 -> 4 -> 8 -> 16 -> 32 -> 64, exactly 7 steps and 256 * 7 = 1792 power drained.

# Proposed fix

Copy the `output` reference so Forge doesn't mutate it. This way the Condenser correctly adds 1 output item per loop step.

# Miscellanea

Removes Player's maven in favor of CurseMaven. It's down nearly all the time. 