### PR TITLE
Fix data loss in BasicCellInventory

### DIFF
--- a/src/main/java/appeng/me/storage/BasicCellInventory.java
+++ b/src/main/java/appeng/me/storage/BasicCellInventory.java
@@ -140,7 +140,7 @@ public class BasicCellInventory<T extends IAEStack<T>> extends AbstractCellInven
 
         if (this.canHoldNewItem()) // room for new type, and for at least one item!
         {
-            final int remainingItemCount = (int) this.getRemainingItemCount() - this.getBytesPerType() * this.itemsPerByte;
+            final long remainingItemCount = this.getRemainingItemCount() - (long) this.getBytesPerType() * this.itemsPerByte;
             if (remainingItemCount > 0) {
                 if (input.getStackSize() > remainingItemCount) {
                     final T toReturn = input.copy();


### PR DESCRIPTION
Makes no sense for int to be used around everything that expects longs. Fixes issues with large fluid cells, specifically, from https://github.com/NotMyWing/NAE2.
![image](https://github.com/PrototypeTrousers/Applied-Energistics-2/assets/22255622/6d01970d-76b9-44df-8c75-315f3868d548)
